### PR TITLE
Make sure we consistently handle checking unit strings to identify de…

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
@@ -226,11 +226,11 @@ class BufrIospBuilder {
       }
     } else {
       String units = fld.getUnits();
-      if (units.equalsIgnoreCase("Code_Table") || units.equalsIgnoreCase("Code Table")) {
+      if (DataDescriptor.isCodeTableUnit(units)) {
         v.addAttribute(new Attribute(CDM.UNITS, "CodeTable " + fld.dds.getFxyName()));
-      } else if (units.equalsIgnoreCase("Flag_Table") || units.equalsIgnoreCase("Flag Table")) {
+      } else if (DataDescriptor.isFlagTableUnit(units)) {
         v.addAttribute(new Attribute(CDM.UNITS, "FlagTable " + fld.dds.getFxyName()));
-      } else if (!units.startsWith("CCITT") && !units.startsWith("Numeric")) {
+      } else if (!DataDescriptor.isInternationalAlphabetUnit(units) && !units.startsWith("Numeric")) {
         v.addAttribute(new Attribute(CDM.UNITS, units));
       }
     }

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/Construct2.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/Construct2.java
@@ -262,12 +262,13 @@ class Construct2 {
         log.warn("dataDesc.units == null for " + uname);
     } else {
       String units = fld.getUnits();
-      if (units.equalsIgnoreCase("Code_Table") || units.equalsIgnoreCase("Code Table"))
+      if (DataDescriptor.isCodeTableUnit(units)) {
         v.addAttribute(new Attribute(CDM.UNITS, "CodeTable " + fld.dds.getFxyName()));
-      else if (units.equalsIgnoreCase("Flag_Table") || units.equalsIgnoreCase("Flag Table"))
+      } else if (DataDescriptor.isFlagTableUnit(units)) {
         v.addAttribute(new Attribute(CDM.UNITS, "FlagTable " + fld.dds.getFxyName()));
-      else if (!units.startsWith("CCITT") && !units.startsWith("Numeric"))
+      } else if (!DataDescriptor.isInternationalAlphabetUnit(units) && !units.startsWith("Numeric")) {
         v.addAttribute(new Attribute(CDM.UNITS, units));
+      }
     }
 
     DataDescriptor dataDesc = fld.dds;

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/DataDescriptor.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/DataDescriptor.java
@@ -77,6 +77,46 @@ public class DataDescriptor {
     }
   }
 
+  /**
+   * Test is unit string indicates that the data are 7-bit coded characters following
+   * the International Reference Alphabet (formally known as the International Alphabet
+   * No.5 (IA5)) Recommendation/International Standard from the International Telegraph
+   * and Telephone Consultative Committee (CCITT)
+   *
+   * https://www.itu.int/rec/T-REC-T.50/en
+   *
+   * @param unitString unit
+   * @return If true, treat the data as 7-bit coded International Reference Alphabet Characters
+   */
+  public static boolean isInternationalAlphabetUnit(String unitString) {
+    String testUnitString = unitString.toLowerCase();
+    return testUnitString.startsWith("ccitt");
+  }
+
+  /**
+   * Test if the unit string indicates that we are dealing with data associated with a code table
+   *
+   * @param unitString unit
+   * @return If true, the unit indicates we are working with data associated with a code table
+   */
+  public static boolean isCodeTableUnit(String unitString) {
+    String testUnitString = unitString.toLowerCase();
+    return testUnitString.equalsIgnoreCase("Code Table") || testUnitString.equalsIgnoreCase("Code_Table")
+        || testUnitString.startsWith("codetable");
+  }
+
+  /**
+   * Test if the unit string indicates that we are dealing with data associated with a flag table
+   *
+   * @param unitString unit
+   * @return If true, the unit indicates we are working with data associated with a flag table
+   */
+  public static boolean isFlagTableUnit(String unitString) {
+    String testUnitString = unitString.toLowerCase();
+    return testUnitString.equalsIgnoreCase("Flag Table") || testUnitString.equalsIgnoreCase("Flag_Table")
+        || testUnitString.startsWith("flagtable");
+  }
+
   private void setDescriptor(TableB.Descriptor d) {
     this.name = d.getName().trim();
     this.units = d.getUnits().trim();
@@ -87,13 +127,12 @@ public class DataDescriptor {
     this.localOverride = d.getLocalOverride();
     this.source = d.getSource();
 
-    if (units.equalsIgnoreCase("CCITT IA5") || units.equalsIgnoreCase("CCITT_IA5")) {
+    if (isInternationalAlphabetUnit(units)) {
       this.type = 1; // String
-      // this.bitWidth *= 8;
     }
 
     // LOOK what about flag table ??
-    if (units.equalsIgnoreCase("Code Table") || units.equalsIgnoreCase("Code_Table")) {
+    if (isCodeTableUnit(units)) {
       this.type = 2; // enum
     }
   }

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/TableB.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/TableB.java
@@ -6,6 +6,7 @@ package ucar.nc2.iosp.bufr.tables;
 
 import javax.annotation.concurrent.Immutable;
 import java.util.*;
+import ucar.nc2.iosp.bufr.DataDescriptor;
 
 /**
  * BUFR Table B - Data descriptors
@@ -128,7 +129,7 @@ public class TableB {
       this.units = units.trim().intern();
       this.desc = desc;
 
-      this.numeric = !this.units.startsWith("CCITT");
+      this.numeric = !DataDescriptor.isInternationalAlphabetUnit(units);
     }
 
     public int getScale() {


### PR DESCRIPTION
…scriptor type

We were identifying unit values `CCITT IA5` and `CCITT_IA5` as
indicating descriptor type string, but not `CCITTIA5`. This was causing
some tests to fail with the new BUFR files added to thredds-test-data. Now
we do this check in one method. This PR also makes sure we do the same for
Code Table and Flag table units (also checking for `CODETABLE` and
`FLAGTABLE`, as that is what is used in the eumetsat tables). Oh,
BUFR...you so silly.